### PR TITLE
refactor: Add test Make target and avoid escaping $

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/fastjet:test
-        -c "g++ tests/test_short_example.cc -o tests/short_example \$(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/short_example"
+        -c 'g++ tests/test_short_example.cc -o tests/short_example $(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/short_example'
     - name: Run test program in Python
       run: >-
         docker run --rm

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,18 @@ run_local:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/fastjet:latest
+
+test:
+	# Use single quotes to not exapnd contens of $()
+	docker run \
+		--rm \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		matthewfeickert/fastjet:latest \
+		-c 'g++ tests/test_short_example.cc -o tests/short_example $$(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/short_example'
+	docker run \
+		--rm \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		matthewfeickert/fastjet:latest \
+		-c "python tests/test_python.py"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can either use the image as "`FastJet` as a service", as demoed here with th
 
 ```
 docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/fastjet:fastjet3.3.3 \
-  -c "g++ tests/test_short_example.cc -o tests/short_example \$(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/short_example"
+  -c 'g++ tests/test_short_example.cc -o tests/short_example $(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/short_example'
 ```
 
 or using the Python bindings


### PR DESCRIPTION
Add tests to Makefile, and use single quotes to avoid escaping `$`, given that single quotes don't expand the contents of `$`

Thanks to @kratsg for pointing this out!

c.f. https://stackoverflow.com/questions/26564825/what-is-the-meaning-of-a-double-dollar-sign-in-bash-makefile

```
* Add test Make target
* Use single quotes to avoid escaping $ for easier readability
```